### PR TITLE
Fix site url

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -30,7 +30,7 @@ Links([
         "icon":"fab fa-kaggle",
     },
     {
-        "href":"https://ashokricom",
+        "href":"https://ashokri.com",
         "icon":"fab fa-wordpress",
     }
 


### PR DESCRIPTION
Hi,

Your we page had a problem. Wordpress icon link was wrong.
It was like this `https://ashokricom`.

So, I forked it and found the link. At last, fixed it and commit it. Now it is like this `https://ashokri.com`!

Hope your enjoy and merge this P.R.

May the force be with you.
Amir.